### PR TITLE
Added DateOnly as a known type, so it is used in the schema and when …

### DIFF
--- a/src/Dynamicweb.DataIntegration.Providers.ODataProvider.csproj
+++ b/src/Dynamicweb.DataIntegration.Providers.ODataProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>10.6.0</Version>
+		<Version>10.6.1</Version>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>OData Provider</Title>
 		<Description>The Odata Provider lets you fetch and map data from or to any OData endpoint.</Description>

--- a/src/ODataProvider.cs
+++ b/src/ODataProvider.cs
@@ -410,6 +410,7 @@ public class ODataProvider : BaseProvider, ISource, IDestination, IParameterOpti
             case "Edm.Stream":
                 return typeof(Stream);
             case "Edm.Date":
+                return typeof(DateOnly);
             case "Edm.DateTimeOffset":
                 return typeof(DateTime);
             case "Edm.Boolean":

--- a/src/ODataSourceReader.cs
+++ b/src/ODataSourceReader.cs
@@ -276,7 +276,9 @@ internal class ODataSourceReader : ISourceReader
                     {
                         if (_mapping.SourceTable.Columns.Any(obj => obj.Name.Equals(delta, StringComparison.OrdinalIgnoreCase)))
                         {
-                            dateTimeFilterName = _mapping.SourceTable.Columns.Where(obj => obj.Name.Equals(delta, StringComparison.OrdinalIgnoreCase)).First().Name;
+                            var dateTimeFilterColumn = _mapping.SourceTable.Columns.Where(obj => obj.Name.Equals(delta, StringComparison.OrdinalIgnoreCase)).First();
+                            isEdmDate = dateTimeFilterColumn.Type == typeof(DateOnly);
+                            dateTimeFilterName = dateTimeFilterColumn.Name;
                             break;
                         }
                     }
@@ -290,11 +292,9 @@ internal class ODataSourceReader : ISourceReader
                         {
                             case "Last_Date_Modified":
                                 dateTimeFilterName = "Last_Date_Modified";
-                                isEdmDate = true;
                                 break;
                             case "Order_Date":
                                 dateTimeFilterName = "Order_Date";
-                                isEdmDate = true;
                                 break;
                             case "LastDateTimeModified":
                                 dateTimeFilterName = "LastDateTimeModified";
@@ -306,6 +306,7 @@ internal class ODataSourceReader : ISourceReader
                                 dateTimeFilterName = "modifiedon";
                                 break;
                         }
+                        isEdmDate = column.Type == typeof(DateOnly);
                     }
                 }
 
@@ -707,7 +708,8 @@ internal class ODataSourceReader : ISourceReader
             }
             else
             {
-                _logger?.Info($"{checkUrl} returned the HttpStatusCode of: '{responseStatusCode}' ");
+                StreamReader reader = new(responseStream);
+                _logger?.Info($"{checkUrl} returned the HttpStatusCode of: '{responseStatusCode}' {reader.ReadToEnd()}");
             }
         }
         return result;

--- a/src/ODataWriter.cs
+++ b/src/ODataWriter.cs
@@ -333,25 +333,23 @@ internal class ODataWriter : IDisposable, IDestinationWriter
         if (DateTime.TryParse(inputString, CultureInfo.InvariantCulture, out var dateTime) ||
             DateTime.TryParseExact(inputString, "dd-MM-yyyy HH:mm:ss:fff", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateTime))
         {
-            DateTime dateTimeInUtc;
-            if (SqlDateTime.MinValue.Value > dateTime || DateTime.MinValue > dateTime)
+            if (dateTime <= SqlDateTime.MinValue.Value || dateTime <= DateTime.MinValue)
             {
-                return DateTime.MinValue.ToString("yyyy-MM-dd");
+                return null;
             }
-            else if (SqlDateTime.MaxValue.Value < dateTime || DateTime.MaxValue < dateTime)
+            else if (dateTime >= SqlDateTime.MaxValue.Value || dateTime >= DateTime.MaxValue)
             {
-                return DateTime.MaxValue.ToString("yyyy-MM-dd");
+                return null;
             }
 
-            dateTimeInUtc = TimeZoneInfo.ConvertTimeToUtc(dateTime);
-
-            if (dateTimeInUtc.TimeOfDay.TotalMilliseconds > 0 && !isEdmDate)
+            if (!isEdmDate)
             {
+                var dateTimeInUtc = TimeZoneInfo.ConvertTimeToUtc(dateTime);
                 return dateTimeInUtc.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture) + "z";
             }
             else
             {
-                return dateTimeInUtc.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                return dateTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             }
         }
         return null;


### PR DESCRIPTION
…converting date/datetimes and $filters. plus when checking for endpoint is ready for use it also adds response to the log instead of just the status code.